### PR TITLE
RU-AXAV: cs & thread: repair thread-break on terminated thread

### DIFF
--- a/pkgs/racket-test-core/tests/racket/thread.rktl
+++ b/pkgs/racket-test-core/tests/racket/thread.rktl
@@ -1665,6 +1665,18 @@
 (test #t integer? (current-process-milliseconds 'subprocesses))
 (err/rt-test (current-process-milliseconds 'other))
 
+;; --------------------
+;; Check `thread-break` on a thread kiled while it tried to sync:
+
+(let ()
+  (define t (thread (lambda () (sync never-evt))))
+  (sync (system-idle-evt))
+  (kill-thread t)
+  (test #t thread-dead? t)
+  (sync (system-idle-evt))
+  (test (void) break-thread t)
+  (test #t thread-dead? t))
+
 ; --------------------
 
 (report-errs)

--- a/racket/src/cs/schemified/thread.scm
+++ b/racket/src/cs/schemified/thread.scm
@@ -7886,30 +7886,32 @@
        (begin
          (start-atomic)
          (begin0
-           (let ((c1_0 (thread-forward-break-to t_0)))
-             (if c1_0
-               (lambda () (do-break-thread c1_0 kind_0 check-t_0))
-               (begin
-                 (if (if (thread-pending-break t_0)
-                       (break>? kind_0 (thread-pending-break t_0))
-                       #f)
-                   (set-thread-pending-break! t_0 kind_0)
-                   (void))
-                 (if (thread-pending-break t_0)
-                   (void)
-                   (begin
+           (if (1/thread-dead? t_0)
+             void
+             (let ((c1_0 (thread-forward-break-to t_0)))
+               (if c1_0
+                 (lambda () (do-break-thread c1_0 kind_0 check-t_0))
+                 (begin
+                   (if (if (thread-pending-break t_0)
+                         (break>? kind_0 (thread-pending-break t_0))
+                         #f)
                      (set-thread-pending-break! t_0 kind_0)
-                     (thread-did-work!)
-                     (run-suspend/resume-callbacks t_0 car)
-                     (run-suspend/resume-callbacks t_0 cdr)
-                     (if (thread-descheduled? t_0)
-                       (if (thread-suspended? t_0)
-                         (void)
-                         (begin
-                           (run-interrupt-callback t_0)
-                           (thread-reschedule! t_0)))
-                       (void))))
-                 void)))
+                     (void))
+                   (if (thread-pending-break t_0)
+                     (void)
+                     (begin
+                       (set-thread-pending-break! t_0 kind_0)
+                       (thread-did-work!)
+                       (run-suspend/resume-callbacks t_0 car)
+                       (run-suspend/resume-callbacks t_0 cdr)
+                       (if (thread-descheduled? t_0)
+                         (if (thread-suspended? t_0)
+                           (void)
+                           (begin
+                             (run-interrupt-callback t_0)
+                             (thread-reschedule! t_0)))
+                         (void))))
+                   void))))
            (end-atomic))))
       (if (eq? t_0 check-t_0)
         (begin

--- a/racket/src/thread/thread.rkt
+++ b/racket/src/thread/thread.rkt
@@ -846,6 +846,7 @@
 (define (do-break-thread t kind check-t)
   ((atomically
     (cond
+      [(thread-dead? t) void]
       [(thread-forward-break-to t)
        => (lambda (other-t)
             (lambda () (do-break-thread other-t kind check-t)))]


### PR DESCRIPTION
The `threadbreak` function should not try to reschedule a terminated
thread.

Thanks to Daniel Holtby for the report and text case.